### PR TITLE
INTERLOK-3329 #comment Deprecated destination and use a new url member.

### DIFF
--- a/src/main/java/com/adaptris/core/socket/ProduceConnection.java
+++ b/src/main/java/com/adaptris/core/socket/ProduceConnection.java
@@ -41,14 +41,14 @@ public abstract class ProduceConnection extends NoOpConnection {
   }
 
   /** Create the socket that will be used by the Producer.
-   *  <p>The destination is expected to be a URL that can be handled by the
+   *  <p>The url is expected to be a valid URL that can be handled by the
    *  concrete implementation of ProduceConnection.
    * @return the socket.
-   * @param dest the destination to produce to.
+   * @param url the url destination to produce to.
    * @throws IOException if there was an error creating a socket, or if the
    * destination was unparseable
    */
-  public abstract Socket createSocket(String dest) throws IOException;
+  public abstract Socket createSocket(String url) throws IOException;
   
   /** Get the configured timeout.
    * 

--- a/src/main/java/com/adaptris/core/socket/SocketProducer.java
+++ b/src/main/java/com/adaptris/core/socket/SocketProducer.java
@@ -12,23 +12,36 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.socket;
 
 import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
+import static com.adaptris.core.util.DestinationHelper.mustHaveEither;
+
 import java.net.Socket;
 import java.util.Map;
+
+import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ProduceDestination;
 import com.adaptris.core.ProduceException;
 import com.adaptris.core.RequestReplyProducerImp;
+import com.adaptris.core.util.DestinationHelper;
+import com.adaptris.core.util.LoggingHelper;
+import com.adaptris.interlok.util.Closer;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Message Producer implemention for TCP.
@@ -42,18 +55,45 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("socket-producer")
 @AdapterComponent
 @ComponentProfile(summary = "Write a arbitrary message to a socket", tag = "producer,socket,tcp",
-    recommended = {ProduceConnection.class})
-@DisplayOrder(order = {"protocolImplementation"})
+recommended = {ProduceConnection.class})
+@DisplayOrder(order = {"protocolImplementation", "url"})
 public class SocketProducer extends RequestReplyProducerImp {
 
+  private static final long DEFAULT_TIMEOUT = 300000;
+
+  /**
+   * The protocol implementation used by the socket.
+   *
+   * @see Protocol
+   */
+  @Getter
+  @Setter
   @NotBlank
   private String protocolImplementation;
-  private static final long DEFAULT_TIMEOUT = 300000;
+  /**
+   * The URL used by the socket to send the message.
+   */
+  @InputFieldHint(expression = true)
+  @Getter
+  @Setter
+  // Needs to be @NotBlank when destination is removed.
+  private String url;
+  @Getter
+  @Setter
+  @Deprecated
+  @Valid
+  @Removal(version = "4.0.0", message = "Use 'url' instead if possible")
+  private ProduceDestination destination;
+
+  private transient boolean destinationWarningLogged = false;
 
   @Override
   public void prepare() throws CoreException {
+    DestinationHelper.logWarningIfNotNull(destinationWarningLogged,
+        () -> destinationWarningLogged = true, getDestination(),
+        "{} uses destination, use 'url' instead", LoggingHelper.friendlyName(this));
+    mustHaveEither(getUrl(), getDestination());
   }
-
 
   /**
    *
@@ -64,123 +104,57 @@ public class SocketProducer extends RequestReplyProducerImp {
     return DEFAULT_TIMEOUT;
   }
 
-  /**
-   * @see com.adaptris.core.AdaptrisMessageProducerImp#produce(AdaptrisMessage,ProduceDestination)
-   */
   @Override
-  public void produce(AdaptrisMessage msg, ProduceDestination destination)
+  protected void doProduce(AdaptrisMessage msg, String endpoint) throws ProduceException {
+    sendMessage(msg, endpoint, DEFAULT_TIMEOUT, false);
+  }
+
+  @Override
+  protected AdaptrisMessage doRequest(AdaptrisMessage msg, String endpoint, long timeout)
       throws ProduceException {
-    sendMessage(msg, destination, DEFAULT_TIMEOUT, false);
+    return sendMessage(msg, endpoint, timeout, true);
   }
 
-  /**
-   * @see com.adaptris.core.AdaptrisComponent#init()
-   */
-  @Override
-  public void init() throws CoreException {
-    ;
-  }
-
-  /**
-   * @see com.adaptris.core.AdaptrisComponent#start()
-   */
-  @Override
-  public void start() throws CoreException {
-    ;
-  }
-
-  /**
-   * @see com.adaptris.core.AdaptrisComponent#stop()
-   */
-  @Override
-  public void stop() {
-    ;
-  }
-
-  /**
-   * @see com.adaptris.core.AdaptrisComponent#close()
-   */
-  @Override
-  public void close() {
-    ;
-  }
-
-  /**
-   *
-   * @see RequestReplyProducerImp#doRequest(AdaptrisMessage, ProduceDestination,
-   *      long)
-   */
-  @Override
-  public AdaptrisMessage doRequest(AdaptrisMessage msg,
-                                ProduceDestination destination, long timeout)
-      throws ProduceException {
-
-    return sendMessage(msg, destination, timeout, true);
-  }
-
-  private AdaptrisMessage sendMessage(AdaptrisMessage msg,
-                                   ProduceDestination dest, long timeout,
-                                   boolean expectReply) throws ProduceException {
+  private AdaptrisMessage sendMessage(AdaptrisMessage msg, String url, long timeout,
+      boolean expectReply) throws ProduceException {
 
     Protocol p = null;
     AdaptrisMessage reply = defaultIfNull(getMessageFactory()).newMessage();
     Socket sock = null;
     try {
-      String host = dest.getDestination(msg);
-      Map m = msg.getObjectHeaders();
+      Map<Object, Object> m = msg.getObjectHeaders();
       // Use the object metadata socket if available.
       sock = m.containsKey(MetadataConstants.SOCKET_OBJECT_KEY)
           ? (Socket) m.get(MetadataConstants.SOCKET_OBJECT_KEY)
-          : retrieveConnection(
-          ProduceConnection.class).createSocket(host);
-      sock.setSoTimeout(timeout >=0 ? new Long(timeout).intValue() : 0);
-      p = (Protocol) Class.forName(protocolImplementation).newInstance();
-      p.setSocket(sock);
-      p.sendDocument(msg.getPayload());
+              : retrieveConnection(
+                  ProduceConnection.class).createSocket(url);
 
-      if (!p.wasSendSuccess()) {
-        throw new Exception("Send of document [" + msg.getUniqueId()
+          sock.setSoTimeout(Math.max(new Long(timeout).intValue(), 0));
+          p = (Protocol) Class.forName(protocolImplementation).newInstance();
+          p.setSocket(sock);
+          p.sendDocument(msg.getPayload());
+
+          if (!p.wasSendSuccess()) {
+            throw new Exception("Send of document [" + msg.getUniqueId()
             + "] failed");
-      }
-      if (expectReply) {
-        reply.setPayload(p.getReplyAsBytes());
-      }
+          }
+          if (expectReply) {
+            reply.setPayload(p.getReplyAsBytes());
+          }
     }
     catch (Exception e) {
       throw new ProduceException(e);
     }
     finally {
       msg.getObjectHeaders().remove(MetadataConstants.SOCKET_OBJECT_KEY);
-      if (sock != null) {
-        try {
-          sock.close();
-        }
-        catch (Exception ignored) {
-          ;
-        }
-      }
+      Closer.closeQuietly(sock);
     }
     return reply;
   }
 
-  /**
-   * Get the protocol implementation.
-   *
-   * @return the protocol implementation
-   * @see Protocol
-   */
-  public String getProtocolImplementation() {
-    return protocolImplementation;
-  }
-
-  /**
-   * Set the protocol implementation.
-   *
-   * @param string the protocol implementation
-   * @see Protocol
-   */
-  public void setProtocolImplementation(String string) {
-    protocolImplementation = string;
+  @Override
+  public String endpoint(AdaptrisMessage msg) throws ProduceException {
+    return DestinationHelper.resolveProduceDestination(getUrl(), getDestination(), msg);
   }
 
 }

--- a/src/main/java/com/adaptris/core/socket/TcpProduceConnection.java
+++ b/src/main/java/com/adaptris/core/socket/TcpProduceConnection.java
@@ -49,13 +49,13 @@ public class TcpProduceConnection extends ProduceConnection {
    * @see ProduceConnection#createSocket(java.lang.String)
    */
   @Override
-  public Socket createSocket(String dest)
+  public Socket createSocket(String url)
     throws IOException, UnsupportedOperationException {
-    URLString url = new URLString(dest);
+    URLString urlString = new URLString(url);
     Socket s = null;
-    if ("tcp".equals(url.getProtocol())) {
+    if ("tcp".equals(urlString.getProtocol())) {
       s = new Socket();
-      InetSocketAddress addr = new InetSocketAddress(url.getHost(), url.getPort());
+      InetSocketAddress addr = new InetSocketAddress(urlString.getHost(), urlString.getPort());
       s.connect(addr, getSocketTimeout());
     }
     else {

--- a/src/test/java/com/adaptris/core/socket/TestSocketConsumer.java
+++ b/src/test/java/com/adaptris/core/socket/TestSocketConsumer.java
@@ -1,27 +1,28 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.socket;
 
 import static com.adaptris.core.PortManager.nextUnusedPort;
 import static com.adaptris.core.PortManager.release;
 import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
+
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.ConsumerCase;
 import com.adaptris.core.DefaultMessageFactory;
 import com.adaptris.core.StandaloneConsumer;
@@ -35,7 +36,7 @@ import com.adaptris.core.stubs.MockMessageListener;
 public class TestSocketConsumer extends ConsumerCase {
   /**
    * Key in unit-test.properties that defines where example goes unless overriden {@link #setBaseDir(String)}.
-   * 
+   *
    */
   public static final String BASE_DIR_KEY = "SocketConsumerExamples.baseDir";
 
@@ -67,7 +68,7 @@ public class TestSocketConsumer extends ConsumerCase {
   }
 
   @Test
-  public void testBasicSendReciver() throws Exception {
+  public void testBasicSendReceiver() throws Exception {
     Integer port = nextUnusedPort(19000);
     MockMessageListener stub = new MockMessageListener();
     StandaloneConsumer consumer = createConsumer(port);
@@ -92,8 +93,7 @@ public class TestSocketConsumer extends ConsumerCase {
 
   private static StandaloneProducer createProducer(Integer port) {
     SocketProducer producer = new SocketProducer();
-    ConfiguredProduceDestination ccd = new ConfiguredProduceDestination("tcp://localhost:" + port);
-    producer.setDestination(ccd);
+    producer.setUrl("tcp://localhost:" + port);
     producer.setProtocolImplementation(SimpleProtocol.class.getName());
     return new StandaloneProducer(new TcpProduceConnection(), producer);
   }

--- a/src/test/java/com/adaptris/core/socket/TestSocketProducer.java
+++ b/src/test/java/com/adaptris/core/socket/TestSocketProducer.java
@@ -16,11 +16,8 @@
 
 package com.adaptris.core.socket;
 
-import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.ProducerCase;
 import com.adaptris.core.StandaloneProducer;
-import com.adaptris.core.socket.SocketProducer;
-import com.adaptris.core.socket.TcpProduceConnection;
 
 /**
  * @author lchan
@@ -45,7 +42,7 @@ public class TestSocketProducer extends ProducerCase {
   protected Object retrieveObjectForSampleConfig() {
     TcpProduceConnection tcp = new TcpProduceConnection();
     SocketProducer producer = new SocketProducer();
-    producer.setDestination(new ConfiguredProduceDestination("tcp://localhost:9099"));
+    producer.setUrl("tcp://localhost:9099");
     producer
         .setProtocolImplementation("my.implementation.of.com.adaptris.core."
             + "socket.Protocol");


### PR DESCRIPTION
## Motivation

Produce Destination is going to be deprecated so that we can have cleaner configuration in the UI. Based on the https://github.com/adaptris/interlok/blob/develop/docs/adr/0005-remove-produce-destination.md

## Modification

- Deprecate the socker producer destination and add warning when used.
- Add a new url member to the socket producer
- Use the new doProduce, doRequest and endpoint methods
- Add javadoc for the destination and the url
- Add url to the order annotation
- Use lombok
- Refactoring

## Testing

- The tests pass
- The changes make sense
